### PR TITLE
SourcePathFinder::findNextNonCompiledPath() considers only test sources

### DIFF
--- a/Services/SourcePathFinder.php
+++ b/Services/SourcePathFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace webignition\BasilWorker\StateBundle\Services;
 
+use webignition\BasilWorker\PersistenceBundle\Entity\Source;
 use webignition\BasilWorker\PersistenceBundle\Services\Repository\TestRepository;
 use webignition\BasilWorker\PersistenceBundle\Services\Store\SourceStore;
 use webignition\StringPrefixRemover\DefinedStringPrefixRemover;
@@ -36,7 +37,7 @@ class SourcePathFinder
 
     public function findNextNonCompiledPath(): ?string
     {
-        $sourcePaths = $this->sourceStore->findAllPaths();
+        $sourcePaths = $this->sourceStore->findAllPaths(Source::TYPE_TEST);
         $testPaths = $this->testRepository->findAllSources();
         $testPaths = $this->removeCompilerSourceDirectoryPrefixFromPaths($testPaths);
 

--- a/Tests/Functional/Services/ApplicationStateTest.php
+++ b/Tests/Functional/Services/ApplicationStateTest.php
@@ -56,8 +56,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ]),
                 'expectedState' => ApplicationState::STATE_COMPILING,
             ],
@@ -65,8 +65,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()->withSource('/app/source/Test/test1.yml'),
@@ -77,8 +77,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()->withSource('/app/source/Test/test1.yml'),
@@ -90,8 +90,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -105,8 +105,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -122,8 +122,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -142,8 +142,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -237,8 +237,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ]),
                 'expectedIsStates' => [
                     ApplicationState::STATE_COMPILING,
@@ -256,8 +256,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()->withSource('/app/source/Test/test1.yml'),
@@ -278,8 +278,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()->withSource('/app/source/Test/test1.yml'),
@@ -301,8 +301,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -326,8 +326,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -353,8 +353,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()
@@ -383,8 +383,8 @@ class ApplicationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()->withPath('Test/test2.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test1.yml'),
+                        SourceConfiguration::createTest()->withPath('Test/test2.yml'),
                     ])
                     ->withTestConfigurations([
                         TestConfiguration::create()

--- a/Tests/Functional/Services/CompilationStateTest.php
+++ b/Tests/Functional/Services/CompilationStateTest.php
@@ -56,9 +56,9 @@ class CompilationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test2.yml'),
                     ]),
                 'expectedState' => CompilationState::STATE_RUNNING,
@@ -67,9 +67,9 @@ class CompilationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test2.yml'),
                     ])
                     ->withCallbackConfigurations([
@@ -82,7 +82,7 @@ class CompilationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test1.yml'),
                     ])
                     ->withTestConfigurations([
@@ -146,9 +146,9 @@ class CompilationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test2.yml'),
                     ]),
                 'expectedIsStates' => [
@@ -165,9 +165,9 @@ class CompilationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test1.yml'),
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test2.yml'),
                     ])
                     ->withCallbackConfigurations([
@@ -188,7 +188,7 @@ class CompilationStateTest extends AbstractFunctionalTest
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations([
-                        SourceConfiguration::create()
+                        SourceConfiguration::createTest()
                             ->withPath('Test/test1.yml'),
                     ])
                     ->withTestConfigurations([

--- a/Tests/Functional/Services/SourcePathFinderTest.php
+++ b/Tests/Functional/Services/SourcePathFinderTest.php
@@ -43,15 +43,21 @@ class SourcePathFinderTest extends AbstractFunctionalTest
     public function findNextNonCompiledPathDataProvider(): array
     {
         $sources = [
-            'Test/testZebra.yml',
+            'Page/page1.yml',
             'Test/testApple.yml',
+            'Page/page2.yml',
             'Test/testBat.yml',
+            'Page/page3.yml',
+            'Test/testZebra.yml',
         ];
 
         $sourceConfigurations = [
-            SourceConfiguration::createTest()->withPath($sources[0]),
+            SourceConfiguration::createResource()->withPath($sources[0]),
             SourceConfiguration::createTest()->withPath($sources[1]),
-            SourceConfiguration::createTest()->withPath($sources[2]),
+            SourceConfiguration::createResource()->withPath($sources[2]),
+            SourceConfiguration::createTest()->withPath($sources[3]),
+            SourceConfiguration::createResource()->withPath($sources[4]),
+            SourceConfiguration::createTest()->withPath($sources[5]),
         ];
 
         return [
@@ -64,45 +70,55 @@ class SourcePathFinderTest extends AbstractFunctionalTest
                     ->withJobConfiguration(JobConfiguration::create()),
                 'expectedNextNonCompiledSource' => null,
             ],
+            'has job, has resource-only sources, no tests' => [
+                'entityConfiguration' => (new EntityConfiguration())
+                    ->withJobConfiguration(JobConfiguration::create())
+                    ->withSourceConfigurations([
+                        $sourceConfigurations[0],
+                        $sourceConfigurations[2],
+                        $sourceConfigurations[4],
+                    ]),
+                'expectedNextNonCompiledSource' => null,
+            ],
             'has job, has sources, no tests' => [
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations($sourceConfigurations),
-                'expectedNextNonCompiledSource' => $sources[0],
-            ],
-            'test exists for first source' => [
-                'entityConfiguration' => (new EntityConfiguration())
-                    ->withJobConfiguration(JobConfiguration::create())
-                    ->withSourceConfigurations($sourceConfigurations)
-                    ->withTestConfigurations([
-                        TestConfiguration::create()
-                            ->withSource('/app/source/' . $sources[0]),
-                    ]),
                 'expectedNextNonCompiledSource' => $sources[1],
             ],
-            'test exists for first and second sources' => [
+            'test exists for first test source' => [
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations($sourceConfigurations)
                     ->withTestConfigurations([
-                        TestConfiguration::create()
-                            ->withSource('/app/source/' . $sources[0]),
                         TestConfiguration::create()
                             ->withSource('/app/source/' . $sources[1]),
                     ]),
-                'expectedNextNonCompiledSource' => $sources[2],
+                'expectedNextNonCompiledSource' => $sources[3],
             ],
-            'tests exist for all sources' => [
+            'test exists for first and second test sources' => [
                 'entityConfiguration' => (new EntityConfiguration())
                     ->withJobConfiguration(JobConfiguration::create())
                     ->withSourceConfigurations($sourceConfigurations)
                     ->withTestConfigurations([
                         TestConfiguration::create()
-                            ->withSource('/app/source/' . $sources[0]),
+                            ->withSource('/app/source/' . $sources[1]),
+                        TestConfiguration::create()
+                            ->withSource('/app/source/' . $sources[3]),
+                    ]),
+                'expectedNextNonCompiledSource' => $sources[5],
+            ],
+            'tests exist for all test sources' => [
+                'entityConfiguration' => (new EntityConfiguration())
+                    ->withJobConfiguration(JobConfiguration::create())
+                    ->withSourceConfigurations($sourceConfigurations)
+                    ->withTestConfigurations([
                         TestConfiguration::create()
                             ->withSource('/app/source/' . $sources[1]),
                         TestConfiguration::create()
-                            ->withSource('/app/source/' . $sources[2]),
+                            ->withSource('/app/source/' . $sources[3]),
+                        TestConfiguration::create()
+                            ->withSource('/app/source/' . $sources[5]),
                     ]),
                 'expectedNextNonCompiledSource' => null,
             ],

--- a/Tests/Functional/Services/SourcePathFinderTest.php
+++ b/Tests/Functional/Services/SourcePathFinderTest.php
@@ -49,9 +49,9 @@ class SourcePathFinderTest extends AbstractFunctionalTest
         ];
 
         $sourceConfigurations = [
-            SourceConfiguration::create()->withPath($sources[0]),
-            SourceConfiguration::create()->withPath($sources[1]),
-            SourceConfiguration::create()->withPath($sources[2]),
+            SourceConfiguration::createTest()->withPath($sources[0]),
+            SourceConfiguration::createTest()->withPath($sources[1]),
+            SourceConfiguration::createTest()->withPath($sources[2]),
         ];
 
         return [
@@ -135,9 +135,9 @@ class SourcePathFinderTest extends AbstractFunctionalTest
         ];
 
         $sourceConfigurations = [
-            SourceConfiguration::create()->withPath($sources[0]),
-            SourceConfiguration::create()->withPath($sources[1]),
-            SourceConfiguration::create()->withPath($sources[2]),
+            SourceConfiguration::createTest()->withPath($sources[0]),
+            SourceConfiguration::createTest()->withPath($sources[1]),
+            SourceConfiguration::createTest()->withPath($sources[2]),
         ];
 
         return [

--- a/Tests/Model/SourceConfiguration.php
+++ b/Tests/Model/SourceConfiguration.php
@@ -15,9 +15,9 @@ class SourceConfiguration
     {
     }
 
-    public static function create(): SourceConfiguration
+    public static function createTest(string $path = 'test.yml'): SourceConfiguration
     {
-        return new SourceConfiguration(Source::TYPE_TEST, 'test.yml');
+        return new SourceConfiguration(Source::TYPE_TEST, $path);
     }
 
     /**

--- a/Tests/Model/SourceConfiguration.php
+++ b/Tests/Model/SourceConfiguration.php
@@ -20,6 +20,11 @@ class SourceConfiguration
         return new SourceConfiguration(Source::TYPE_TEST, $path);
     }
 
+    public static function createResource(string $path = 'page.yml'): SourceConfiguration
+    {
+        return new SourceConfiguration(Source::TYPE_RESOURCE, $path);
+    }
+
     /**
      * @return Source::TYPE_* $type
      */

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "8.*",
         "doctrine/doctrine-bundle": "^2.2",
         "symfony/yaml": "^5.3",
-        "webignition/basil-worker-persistence-bundle": ">=0.24,<1",
+        "webignition/basil-worker-persistence-bundle": ">=0.27,<1",
         "webignition/string-prefix-remover": ">=0.2,<1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0018e7bd0e447917099c460f6e87506",
+    "content-hash": "472a08abb3e72433600f49cb439e7277",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -3762,16 +3762,16 @@
         },
         {
             "name": "webignition/basil-worker-persistence-bundle",
-            "version": "0.24",
+            "version": "0.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webignition/basil-worker-persistence-bundle.git",
-                "reference": "41af7b67508940ac06f690282eb460f5860bc5d5"
+                "reference": "563df4b7ecac917eea2a053561e728c9ac24c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webignition/basil-worker-persistence-bundle/zipball/41af7b67508940ac06f690282eb460f5860bc5d5",
-                "reference": "41af7b67508940ac06f690282eb460f5860bc5d5",
+                "url": "https://api.github.com/repos/webignition/basil-worker-persistence-bundle/zipball/563df4b7ecac917eea2a053561e728c9ac24c87b",
+                "reference": "563df4b7ecac917eea2a053561e728c9ac24c87b",
                 "shasum": ""
             },
             "require": {
@@ -3780,10 +3780,12 @@
                 "php": "8.*",
                 "symfony/config": "^5.2",
                 "symfony/dependency-injection": "^5.2",
-                "symfony/http-kernel": "^5.2"
+                "symfony/http-kernel": "^5.2",
+                "symfony/yaml": "^5.3"
             },
             "require-dev": {
                 "doctrine/doctrine-bundle": "^2.2",
+                "friendsofphp/php-cs-fixer": "^3.0",
                 "mockery/mockery": "^1.4",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^0.12.78",
@@ -3791,8 +3793,7 @@
                 "phpstan/phpstan-phpunit": "^0.12.17",
                 "phpstan/phpstan-symfony": "^0.12.20",
                 "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "dev-master",
-                "symplify/easy-coding-standard": "^9.2",
+                "squizlabs/php_codesniffer": "^3.6",
                 "webignition/object-reflector": "^1.0"
             },
             "type": "symfony-bundle",
@@ -3817,9 +3818,9 @@
             "homepage": "https://github.com/webignition/basil-worker-persistence-bundle",
             "support": {
                 "issues": "https://github.com/webignition/basil-worker-persistence-bundle/issues",
-                "source": "https://github.com/webignition/basil-worker-persistence-bundle/tree/0.24"
+                "source": "https://github.com/webignition/basil-worker-persistence-bundle/tree/0.27"
             },
-            "time": "2021-03-05T17:51:54+00:00"
+            "time": "2021-06-10T16:27:17+00:00"
         },
         {
             "name": "webignition/string-prefix-remover",


### PR DESCRIPTION
Fixes #42